### PR TITLE
use xenial distribution in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 sudo: required
 addons:
   apt:


### PR DESCRIPTION
travis builds valid images when using xenial distribution of ubuntu